### PR TITLE
Kbapi tests

### DIFF
--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/mvn/PackageApi.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/mvn/PackageApi.java
@@ -1,7 +1,9 @@
 package eu.fasten.analyzer.restapiplugin.api.mvn;
 
+import eu.fasten.analyzer.restapiplugin.RestAPIPlugin;
 import eu.fasten.analyzer.restapiplugin.api.RestApplication;
 import eu.fasten.analyzer.restapiplugin.api.mvn.impl.PackageApiServiceImpl;
+import eu.fasten.core.data.metadatadb.MetadataDao;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -13,6 +15,8 @@ public class PackageApi {
 
     PackageApiService service = new PackageApiServiceImpl();
 
+    MetadataDao kbDao = RestAPIPlugin.RestAPIExtension.kbDao;
+
     @GET
     @Path("/{pkg}/versions")
     @Produces(MediaType.APPLICATION_JSON)
@@ -21,7 +25,7 @@ public class PackageApi {
                                        @QueryParam("offset") short offset,
                                        @DefaultValue(RestApplication.DEFAULT_PAGE_SIZE)
                                        @QueryParam("limit") short limit) {
-        return service.getPackageVersions(package_name, offset, limit);
+        return service.getPackageVersions(package_name, offset, limit, kbDao);
     }
 
     @GET
@@ -33,7 +37,7 @@ public class PackageApi {
                                       @QueryParam("offset") short offset,
                                       @DefaultValue(RestApplication.DEFAULT_PAGE_SIZE)
                                       @QueryParam("limit") short limit) {
-        return service.getPackageVersion(package_name, package_version, offset, limit);
+        return service.getPackageVersion(package_name, package_version, offset, limit, kbDao);
     }
 
     @GET
@@ -45,7 +49,7 @@ public class PackageApi {
                                        @QueryParam("offset") short offset,
                                        @DefaultValue(RestApplication.DEFAULT_PAGE_SIZE)
                                        @QueryParam("limit") short limit) {
-        return service.getPackageMetadata(package_name, package_version, offset, limit);
+        return service.getPackageMetadata(package_name, package_version, offset, limit, kbDao);
     }
 
     @GET
@@ -57,7 +61,7 @@ public class PackageApi {
                                         @QueryParam("offset") short offset,
                                         @DefaultValue(RestApplication.DEFAULT_PAGE_SIZE)
                                         @QueryParam("limit") short limit) {
-        return service.getPackageCallgraph(package_name, package_version, offset, limit);
+        return service.getPackageCallgraph(package_name, package_version, offset, limit, kbDao);
     }
 }
 

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/mvn/PackageApiService.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/mvn/PackageApiService.java
@@ -1,25 +1,31 @@
 package eu.fasten.analyzer.restapiplugin.api.mvn;
 
+import eu.fasten.core.data.metadatadb.MetadataDao;
+
 import javax.ws.rs.core.Response;
 
 public interface PackageApiService {
 
     Response getPackageVersions(String package_name,
                                 short offset,
-                                short limit);
+                                short limit,
+                                MetadataDao metadataDao);
 
     Response getPackageVersion(String package_name,
                                String package_version,
                                short offset,
-                               short limit);
+                               short limit,
+                               MetadataDao metadataDao);
 
     Response getPackageMetadata(String package_name,
                                 String package_version,
                                 short offset,
-                                short limit);
+                                short limit,
+                                MetadataDao metadataDao);
 
     Response getPackageCallgraph(String package_name,
                                  String package_version,
                                  short offset,
-                                 short limit);
+                                 short limit,
+                                 MetadataDao metadataDao);
 }

--- a/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/PackageApiServiceImpl.java
+++ b/analyzer/restapi-plugin/src/main/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/PackageApiServiceImpl.java
@@ -2,6 +2,7 @@ package eu.fasten.analyzer.restapiplugin.api.mvn.impl;
 
 import eu.fasten.analyzer.restapiplugin.RestAPIPlugin;
 import eu.fasten.analyzer.restapiplugin.api.mvn.PackageApiService;
+import eu.fasten.core.data.metadatadb.MetadataDao;
 
 import javax.ws.rs.core.Response;
 
@@ -10,8 +11,9 @@ public class PackageApiServiceImpl implements PackageApiService {
     @Override
     public Response getPackageVersions(String package_name,
                                        short offset,
-                                       short limit) {
-        String result = RestAPIPlugin.RestAPIExtension.kbDao.getPackageVersions(package_name, offset, limit);
+                                       short limit,
+                                       MetadataDao metadataDao) {
+        String result = metadataDao.getPackageVersions(package_name, offset, limit);
         return Response.status(200).entity(result).build();
     }
 
@@ -19,8 +21,9 @@ public class PackageApiServiceImpl implements PackageApiService {
     public Response getPackageVersion(String package_name,
                                       String package_version,
                                       short offset,
-                                      short limit) {
-        String result = RestAPIPlugin.RestAPIExtension.kbDao.getPackageVersion(
+                                      short limit,
+                                      MetadataDao metadataDao) {
+        String result = metadataDao.getPackageVersion(
                 package_name, package_version, offset, limit);
         return Response.status(200).entity(result).build();
     }
@@ -29,8 +32,9 @@ public class PackageApiServiceImpl implements PackageApiService {
     public Response getPackageMetadata(String package_name,
                                        String package_version,
                                        short offset,
-                                       short limit) {
-        String result = RestAPIPlugin.RestAPIExtension.kbDao.getPackageMetadata(
+                                       short limit,
+                                       MetadataDao metadataDao) {
+        String result = metadataDao.getPackageMetadata(
                 package_name, package_version, offset, limit);
         return Response.status(200).entity(result).build();
     }
@@ -39,8 +43,9 @@ public class PackageApiServiceImpl implements PackageApiService {
     public Response getPackageCallgraph(String package_name,
                                         String package_version,
                                         short offset,
-                                        short limit) {
-        String result = RestAPIPlugin.RestAPIExtension.kbDao.getPackageCallgraph(
+                                        short limit,
+                                        MetadataDao metadataDao) {
+        String result = metadataDao.getPackageCallgraph(
                 package_name, package_version, offset, limit);
         return Response.status(200).entity(result).build();
     }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/RestAPIPluginTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/RestAPIPluginTest.java
@@ -1,0 +1,4 @@
+package eu.fasten.analyzer.restapiplugin;
+
+public class RestAPIPluginTest {
+}

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/RestApplicationTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/RestApplicationTest.java
@@ -1,0 +1,4 @@
+package eu.fasten.analyzer.restapiplugin.api;
+
+public class RestApplicationTest {
+}

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/BinaryModuleApiTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/BinaryModuleApiTest.java
@@ -1,0 +1,4 @@
+package eu.fasten.analyzer.restapiplugin.api.mvn;
+
+public class BinaryModuleApiTest {
+}

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
@@ -22,12 +22,10 @@ import eu.fasten.core.data.metadatadb.MetadataDao;
 import static org.mockito.Mockito.*;
 
 import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.*;
 
 import javax.ws.rs.core.Response;
 
@@ -35,25 +33,18 @@ import javax.ws.rs.core.Response;
 public class BinaryModuleApiServiceImplUTest {
 
     @Mock
-    Response response;
-
-    @Mock
-    MetadataDao kbDao;
-
-    @Mock
     DSLContext dslContext;
 
     @InjectMocks
     private final BinaryModuleApiServiceImpl service = new BinaryModuleApiServiceImpl();
+    private final RestAPIPlugin.RestAPIExtension restExt = new RestAPIPlugin.RestAPIExtension(9090, "url", "user");
 
-    private RestAPIPlugin.RestAPIExtension restAPIExtension;
+    public final MetadataDao kbDao = RestAPIPlugin.RestAPIExtension.kbDao;
 
-    @BeforeEach
-    public void setUp() {
+    @BeforeAll
+    public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-
-        restAPIExtension = new RestAPIPlugin.RestAPIExtension(9090, "url", "user");
-        restAPIExtension.setDBConnection(dslContext);
+        kbDao.setContext(dslContext);
     }
 
     @Test

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
@@ -17,12 +17,16 @@
  */
 package eu.fasten.analyzer.restapiplugin.api.mvn.impl;
 
+import eu.fasten.analyzer.restapiplugin.RestAPIPlugin;
 import eu.fasten.core.data.metadatadb.MetadataDao;
 import static org.mockito.Mockito.*;
+
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import javax.ws.rs.core.Response;
@@ -36,12 +40,20 @@ public class BinaryModuleApiServiceImplUTest {
     @Mock
     MetadataDao kbDao;
 
+    @Mock
+    DSLContext dslContext;
+
     @InjectMocks
     private final BinaryModuleApiServiceImpl service = new BinaryModuleApiServiceImpl();
+
+    private RestAPIPlugin.RestAPIExtension restAPIExtension;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+
+        restAPIExtension = new RestAPIPlugin.RestAPIExtension(9090, "url", "user");
+        restAPIExtension.setDBConnection(dslContext);
     }
 
     @Test
@@ -53,39 +65,23 @@ public class BinaryModuleApiServiceImplUTest {
     }
 
     @Test
-    public void shouldReturnBinaryMod_whenGetPkgBinaryMod() {
-        // getPackageBinaryModules: should return 200 and the result of the string
-        // if pkg binary modules are found
+    public void shouldCallDaoGetBinaryModMetadataMethod() {
+        String pkgName = "au.org";
+        String pkgVersion = "1.1.1";
+        String binaryMod = "xx";
+        service.getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod);
+        verify(kbDao, times(1)).getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod);
     }
 
     @Test
-    public void shouldReturnErrorMsg_whenPkgBinaryModNotFound() {
-        // getPackageBinaryModules: should return 404
-        // if pkg binary modules are not found
-    }
+    public void shouldCallDaoGetBinaryModFilesMethod() {
+        String pkgName = "au.org";
+        String pkgVersion = "1.1.1";
+        String binaryMod = "xx";
 
-    @Test
-    public void shouldReturnMetadata_whenGetBinaryModMetadata() {
-        // getBinaryModuleMetadata: should return 200 and the result of the string
-        // if pkg binary modules metadata are found
-    }
+        when(service.getBinaryModuleFiles(pkgName, pkgVersion, binaryMod)).thenReturn(response);
 
-    @Test
-    public void shouldReturnErrorMsg_whenGetBinaryModMetadataNotFound() {
-        // getBinaryModuleMetadata: should return 404
-        // if pkg binary modules are not found
-    }
-
-    @Test
-    public void shouldReturnFilesInfo_whenGetBinaryModFiles() {
-        // getBinaryModuleFiles: should return 200 and the result of the string
-        // if pkg binary modules are found
-    }
-
-    @Test
-    public void shouldReturnErrorMsg_whenGetBinaryModFilesNotFound() {
-        // getBinaryModuleFiles: should return 404
-        // if pkg binary modules are not found
+        verify(kbDao, times(1)).getBinaryModuleFiles(pkgName, pkgVersion, binaryMod);
     }
 
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
@@ -20,7 +20,10 @@ package eu.fasten.analyzer.restapiplugin.api.mvn.impl;
 import eu.fasten.analyzer.restapiplugin.RestAPIPlugin;
 import eu.fasten.core.data.metadatadb.MetadataDao;
 
-import org.jooq.DSLContext;
+import eu.fasten.core.data.metadatadb.codegen.tables.BinaryModules;
+import eu.fasten.core.data.metadatadb.codegen.tables.PackageVersions;
+import eu.fasten.core.data.metadatadb.codegen.tables.Packages;
+import org.jooq.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,47 +40,47 @@ import static org.mockito.Mockito.*;
 
 public class BinaryModuleApiServiceImplUTest {
 
-    @Mock
-    DSLContext dslContext;
+//     @Mock
+//     DSLContext dslContext;
 
-    @Mock
-    MetadataDao kbDao;
+//     @Mock
+//     MetadataDao kbDao;
 
-    @InjectMocks
-    private final BinaryModuleApiServiceImpl service = new BinaryModuleApiServiceImpl();
-//    private final RestAPIPlugin.RestAPIExtension restExt = new RestAPIPlugin.RestAPIExtension();
+//     @InjectMocks
+//     private final BinaryModuleApiServiceImpl service = new BinaryModuleApiServiceImpl();
+// //    private final RestAPIPlugin.RestAPIExtension restExt = new RestAPIPlugin.RestAPIExtension();
 
-    @BeforeEach
-    public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
-        var restExt = new RestAPIPlugin.RestAPIExtension();
-        restExt.setDBConnection(dslContext);
-    }
+//     @BeforeEach
+//     public void setUp() throws Exception {
+//         MockitoAnnotations.initMocks(this);
+//         var restExt = new RestAPIPlugin.RestAPIExtension();
+//         restExt.setDBConnection(dslContext);
+//     }
 
-    @Test
-    public void shouldCallDaoGetPkgBinaryModMethod() {
-        String pkgName = "au.org";
-        String pkgVersion = "1.1.1";
-        short offset = 1;
-        short limit = 5;
-        String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
-        Response response = Response.status(200).entity(resultSet).build();
-        when(service.getPackageBinaryModules(pkgName, pkgVersion, offset, limit)).thenReturn(response);
-        verify(kbDao, times(1)).getPackageBinaryModules(pkgName, pkgVersion, offset, limit);
-    }
+//     @Test
+//     public void shouldCallDaoGetPkgBinaryModMethod() {
+//         String pkgName = "au.org";
+//         String pkgVersion = "1.1.1";
+//         short offset = 1;
+//         short limit = 5;
+//         String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
+//         Response response = Response.status(200).entity(resultSet).build();
+//         when(service.getPackageBinaryModules(pkgName, pkgVersion, offset, limit)).thenReturn(response);
+//         verify(kbDao, times(1)).getPackageBinaryModules(pkgName, pkgVersion, offset, limit);
+//     }
 
-    @Test
-    public void shouldCallDaoGetBinaryModMetadataMethod() {
-        String pkgName = "au.org";
-        String pkgVersion = "1.1.1";
-        String binaryMod = "xx";
-        short offset = 1;
-        short limit = 5;
-        String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
-        Response response = Response.status(200).entity(resultSet).build();
-        when(service.getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod, offset, limit)).thenReturn(response);
-        verify(kbDao, times(1)).getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod, offset, limit);
-    }
+//     @Test
+//     public void shouldCallDaoGetBinaryModMetadataMethod() {
+//         String pkgName = "au.org";
+//         String pkgVersion = "1.1.1";
+//         String binaryMod = "xx";
+//         short offset = 1;
+//         short limit = 5;
+//         String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
+//         Response response = Response.status(200).entity(resultSet).build();
+//         when(service.getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod, offset, limit)).thenReturn(response);
+//         verify(kbDao, times(1)).getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod, offset, limit);
+//     }
 
 //    @Test
 //    public void shouldCallDaoGetBinaryModFilesMethod() {

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
@@ -18,6 +18,7 @@
 package eu.fasten.analyzer.restapiplugin.api.mvn.impl;
 
 import eu.fasten.core.data.metadatadb.MetadataDao;
+import static org.mockito.Mockito.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -41,6 +42,14 @@ public class BinaryModuleApiServiceImplUTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldCallDaoGetPkgBinaryModMethod() {
+        String pkgName = "au.org";
+        String pkgVersion = "1.1.1";
+        service.getPackageBinaryModules(pkgName, pkgVersion);
+        verify(kbDao, times(1)).getPackageBinaryModules(pkgName, pkgVersion);
     }
 
     @Test

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
@@ -19,60 +19,71 @@ package eu.fasten.analyzer.restapiplugin.api.mvn.impl;
 
 import eu.fasten.analyzer.restapiplugin.RestAPIPlugin;
 import eu.fasten.core.data.metadatadb.MetadataDao;
-import static org.mockito.Mockito.*;
 
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
 
-import javax.ws.rs.core.Response;
-
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class BinaryModuleApiServiceImplUTest {
 
     @Mock
-    DSLContext dslContext;
+    MetadataDao kbDao;
 
     @InjectMocks
     private final BinaryModuleApiServiceImpl service = new BinaryModuleApiServiceImpl();
-    private final RestAPIPlugin.RestAPIExtension restExt = new RestAPIPlugin.RestAPIExtension(9090, "url", "user");
+//    private final RestAPIPlugin.RestAPIExtension restExt = new RestAPIPlugin.RestAPIExtension();
 
-    public final MetadataDao kbDao = RestAPIPlugin.RestAPIExtension.kbDao;
-
-    @BeforeAll
+    @BeforeEach
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        kbDao.setContext(dslContext);
+//        restExt.setDBConnection(dslContext);
+        var dslContext = Mockito.mock(DSLContext.class);
+        var restExt = new RestAPIPlugin.RestAPIExtension();
+        restExt.setDBConnection(dslContext);
     }
 
     @Test
     public void shouldCallDaoGetPkgBinaryModMethod() {
+//        var kbDao = Mockito.mock(MetadataDao.class);
         String pkgName = "au.org";
         String pkgVersion = "1.1.1";
-        service.getPackageBinaryModules(pkgName, pkgVersion);
-        verify(kbDao, times(1)).getPackageBinaryModules(pkgName, pkgVersion);
+        short offset = 1;
+        short limit = 5;
+        service.getPackageBinaryModules(pkgName, pkgVersion, offset, limit);
+        verify(kbDao, times(1)).getPackageBinaryModules(pkgName, pkgVersion, offset, limit);
     }
 
     @Test
     public void shouldCallDaoGetBinaryModMetadataMethod() {
+//        var kbDao = Mockito.mock(MetadataDao.class);
         String pkgName = "au.org";
         String pkgVersion = "1.1.1";
         String binaryMod = "xx";
-        service.getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod);
-        verify(kbDao, times(1)).getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod);
+        short offset = 1;
+        short limit = 5;
+        service.getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod, offset, limit);
+        verify(kbDao, times(1)).getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod, offset, limit);
     }
 
-    @Test
-    public void shouldCallDaoGetBinaryModFilesMethod() {
-        String pkgName = "au.org";
-        String pkgVersion = "1.1.1";
-        String binaryMod = "xx";
-
-        when(service.getBinaryModuleFiles(pkgName, pkgVersion, binaryMod)).thenReturn(response);
-
-        verify(kbDao, times(1)).getBinaryModuleFiles(pkgName, pkgVersion, binaryMod);
-    }
+//    @Test
+//    public void shouldCallDaoGetBinaryModFilesMethod() {
+//        String pkgName = "au.org";
+//        String pkgVersion = "1.1.1";
+//        String binaryMod = "xx";
+//
+//        when(service.getBinaryModuleFiles(pkgName, pkgVersion, binaryMod)).thenReturn(response);
+//
+//        verify(restExt.kbDao, times(1)).getBinaryModuleFiles(pkgName, pkgVersion, binaryMod);
+//    }
 
 }

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.fasten.analyzer.restapiplugin.api.mvn.impl;
+
+import eu.fasten.core.data.metadatadb.MetadataDao;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.ws.rs.core.Response;
+
+
+public class BinaryModuleApiServiceImplUTest {
+
+    @Mock
+    Response response;
+
+    @Mock
+    MetadataDao kbDao;
+
+    @InjectMocks
+    private final BinaryModuleApiServiceImpl service = new BinaryModuleApiServiceImpl();
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldReturnBinaryMod_whenGetPkgBinaryMod() {
+        // getPackageBinaryModules: should return 200 and the result of the string
+        // if pkg binary modules are found
+    }
+
+    @Test
+    public void shouldReturnErrorMsg_whenPkgBinaryModNotFound() {
+        // getPackageBinaryModules: should return 404
+        // if pkg binary modules are not found
+    }
+
+    @Test
+    public void shouldReturnMetadata_whenGetBinaryModMetadata() {
+        // getBinaryModuleMetadata: should return 200 and the result of the string
+        // if pkg binary modules metadata are found
+    }
+
+    @Test
+    public void shouldReturnErrorMsg_whenGetBinaryModMetadataNotFound() {
+        // getBinaryModuleMetadata: should return 404
+        // if pkg binary modules are not found
+    }
+
+    @Test
+    public void shouldReturnFilesInfo_whenGetBinaryModFiles() {
+        // getBinaryModuleFiles: should return 200 and the result of the string
+        // if pkg binary modules are found
+    }
+
+    @Test
+    public void shouldReturnErrorMsg_whenGetBinaryModFilesNotFound() {
+        // getBinaryModuleFiles: should return 404
+        // if pkg binary modules are not found
+    }
+
+}

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/BinaryModuleApiServiceImplUTest.java
@@ -31,10 +31,14 @@ import org.mockito.MockitoAnnotations;
 //import org.mockito.InjectMocks;
 //import org.mockito.Mock;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import javax.ws.rs.core.Response;
+
+import static org.mockito.Mockito.*;
 
 public class BinaryModuleApiServiceImplUTest {
+
+    @Mock
+    DSLContext dslContext;
 
     @Mock
     MetadataDao kbDao;
@@ -46,32 +50,32 @@ public class BinaryModuleApiServiceImplUTest {
     @BeforeEach
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-//        restExt.setDBConnection(dslContext);
-        var dslContext = Mockito.mock(DSLContext.class);
         var restExt = new RestAPIPlugin.RestAPIExtension();
         restExt.setDBConnection(dslContext);
     }
 
     @Test
     public void shouldCallDaoGetPkgBinaryModMethod() {
-//        var kbDao = Mockito.mock(MetadataDao.class);
         String pkgName = "au.org";
         String pkgVersion = "1.1.1";
         short offset = 1;
         short limit = 5;
-        service.getPackageBinaryModules(pkgName, pkgVersion, offset, limit);
+        String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
+        Response response = Response.status(200).entity(resultSet).build();
+        when(service.getPackageBinaryModules(pkgName, pkgVersion, offset, limit)).thenReturn(response);
         verify(kbDao, times(1)).getPackageBinaryModules(pkgName, pkgVersion, offset, limit);
     }
 
     @Test
     public void shouldCallDaoGetBinaryModMetadataMethod() {
-//        var kbDao = Mockito.mock(MetadataDao.class);
         String pkgName = "au.org";
         String pkgVersion = "1.1.1";
         String binaryMod = "xx";
         short offset = 1;
         short limit = 5;
-        service.getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod, offset, limit);
+        String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
+        Response response = Response.status(200).entity(resultSet).build();
+        when(service.getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod, offset, limit)).thenReturn(response);
         verify(kbDao, times(1)).getBinaryModuleMetadata(pkgName, pkgVersion, binaryMod, offset, limit);
     }
 

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/PackageApiServiceImplUTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/PackageApiServiceImplUTest.java
@@ -41,10 +41,13 @@ public class PackageApiServiceImplUTest {
     @BeforeEach
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
+        // TODO: delete all comments before open the PR to merge this into `kbapi` branch
+        // you can do it by simply reverting the last commit ;)
     }
 
     @Test
     public void shouldCallDaoGetPkgVersionsMethod() {
+        // GIVEN **********
         String pkgName = "au.org";
         short offset = 1;
         short limit = 5;
@@ -52,18 +55,25 @@ public class PackageApiServiceImplUTest {
         String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
         Response response = Response.status(200).entity(resultSet).build();
 
+        // Mock all possible DB calls the service might need
         when(mdDao.getPackageVersions(pkgName, offset, limit)).thenReturn(resultSet);
 
+        // WHEN **********
+        // you call this method...
         var servResp = service.getPackageVersions(pkgName, offset, limit, mdDao);
 
+        // THEN **********
+        // assert if the service response content is the expected one
 //        assertEquals(response, servResp);
         // FIXME: this might not work. Needs to find a way to assert the entity content and not the response object
 
+        // verify if the DB method was called once
         verify(mdDao, times(1)).getPackageVersions(pkgName, offset, limit);
     }
 
     @Test
     public void shouldCallDaoGetPkgVersionMethod() {
+        // GIVEN **********
         String pkgName = "au.org";
         String pkgVersion = "1.1.1";
         short offset = 1;
@@ -72,51 +82,73 @@ public class PackageApiServiceImplUTest {
         String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
         Response response = Response.status(200).entity(resultSet).build();
 
+        // Mock all possible DB calls the service might need
         when(mdDao.getPackageVersion(pkgName, pkgVersion, offset, limit)).thenReturn(resultSet);
 
+        // WHEN **********
+        // you call this method...
         var servResp = service.getPackageVersion(pkgName, pkgVersion, offset, limit, mdDao);
 
+        // THEN **********
+        // assert if the service response content is the expected one
 //        assertEquals(response, servResp);
         // FIXME: this might not work. Needs to find a way to assert the entity content and not the response object
 
+        // verify if the DB method was called once
         verify(mdDao, times(1)).getPackageVersion(pkgName, pkgVersion, offset, limit);
     }
 
     @Test
     public void shouldCallDaoGetPkgMetadataMethod() {
+        // GIVEN **********
         String pkgName = "au.org";
         String pkgVersion = "1.1.1";
         short offset = 1;
         short limit = 5;
+        // TODO: update the result set to a correct one
         String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
         Response response = Response.status(200).entity(resultSet).build();
 
+        // Mock all possible DB calls the service might need
         when(mdDao.getPackageMetadata(pkgName, pkgVersion, offset, limit)).thenReturn(resultSet);
 
+        // WHEN **********
+        // you call this method...
         var servResp = service.getPackageMetadata(pkgName, pkgVersion, offset, limit, mdDao);
 
+        // THEN **********
+        // assert if the service response content is the expected one
 //        assertEquals(response, servResp);
         // FIXME: this might not work. Needs to find a way to assert the entity content and not the response object
 
+        // verify if the DB method was called once
         verify(mdDao, times(1)).getPackageMetadata(pkgName, pkgVersion, offset, limit);
     }
 
     @Test
     public void shouldCallDaoGetPkgCallgraphMethod() {
+        // GIVEN **********
         String pkgName = "au.org";
         String pkgVersion = "1.1.1";
         short offset = 1;
         short limit = 5;
+        // TODO: update the result set to a correct one
         String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
         Response response = Response.status(200).entity(resultSet).build();
 
+        // Mock all possible DB calls the service might need
         when(mdDao.getPackageCallgraph(pkgName, pkgVersion, offset, limit)).thenReturn(resultSet);
 
+        // WHEN **********
+        // you call this method...
         var servResp = service.getPackageCallgraph(pkgName, pkgVersion, offset, limit, mdDao);
 
+        // THEN **********
+        // assert if the service response content is the expected one
 //        assertEquals(response, servResp);
         // FIXME: this might not work. Needs to find a way to assert the entity content and not the response object
 
+        // verify if the DB method was called once
         verify(mdDao, times(1)).getPackageCallgraph(pkgName, pkgVersion, offset, limit);
     }
 

--- a/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/PackageApiServiceImplUTest.java
+++ b/analyzer/restapi-plugin/src/test/java/eu/fasten/analyzer/restapiplugin/api/mvn/impl/PackageApiServiceImplUTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.fasten.analyzer.restapiplugin.api.mvn.impl;
+
+import eu.fasten.core.data.metadatadb.MetadataDao;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.ws.rs.core.Response;
+
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class PackageApiServiceImplUTest {
+
+    @InjectMocks
+    private final PackageApiServiceImpl service = new PackageApiServiceImpl();
+
+    @Mock
+    MetadataDao mdDao;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void shouldCallDaoGetPkgVersionsMethod() {
+        String pkgName = "au.org";
+        short offset = 1;
+        short limit = 5;
+        // TODO: update the result set to a correct one
+        String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
+        Response response = Response.status(200).entity(resultSet).build();
+
+        when(mdDao.getPackageVersions(pkgName, offset, limit)).thenReturn(resultSet);
+
+        var servResp = service.getPackageVersions(pkgName, offset, limit, mdDao);
+
+//        assertEquals(response, servResp);
+        // FIXME: this might not work. Needs to find a way to assert the entity content and not the response object
+
+        verify(mdDao, times(1)).getPackageVersions(pkgName, offset, limit);
+    }
+
+    @Test
+    public void shouldCallDaoGetPkgVersionMethod() {
+        String pkgName = "au.org";
+        String pkgVersion = "1.1.1";
+        short offset = 1;
+        short limit = 5;
+        // TODO: update the result set to a correct one
+        String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
+        Response response = Response.status(200).entity(resultSet).build();
+
+        when(mdDao.getPackageVersion(pkgName, pkgVersion, offset, limit)).thenReturn(resultSet);
+
+        var servResp = service.getPackageVersion(pkgName, pkgVersion, offset, limit, mdDao);
+
+//        assertEquals(response, servResp);
+        // FIXME: this might not work. Needs to find a way to assert the entity content and not the response object
+
+        verify(mdDao, times(1)).getPackageVersion(pkgName, pkgVersion, offset, limit);
+    }
+
+    @Test
+    public void shouldCallDaoGetPkgMetadataMethod() {
+        String pkgName = "au.org";
+        String pkgVersion = "1.1.1";
+        short offset = 1;
+        short limit = 5;
+        String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
+        Response response = Response.status(200).entity(resultSet).build();
+
+        when(mdDao.getPackageMetadata(pkgName, pkgVersion, offset, limit)).thenReturn(resultSet);
+
+        var servResp = service.getPackageMetadata(pkgName, pkgVersion, offset, limit, mdDao);
+
+//        assertEquals(response, servResp);
+        // FIXME: this might not work. Needs to find a way to assert the entity content and not the response object
+
+        verify(mdDao, times(1)).getPackageMetadata(pkgName, pkgVersion, offset, limit);
+    }
+
+    @Test
+    public void shouldCallDaoGetPkgCallgraphMethod() {
+        String pkgName = "au.org";
+        String pkgVersion = "1.1.1";
+        short offset = 1;
+        short limit = 5;
+        String resultSet = "{\"fields\":[{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"package_version_id\",\"type\":\"BIGINT\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"name\",\"type\":\"CLOB\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"created_at\",\"type\":\"TIMESTAMP\"},{\"schema\":\"public\",\"table\":\"binary_modules\",\"name\":\"metadata\",\"type\":\"JSONB\"}],\"records\":[]}\n";
+        Response response = Response.status(200).entity(resultSet).build();
+
+        when(mdDao.getPackageCallgraph(pkgName, pkgVersion, offset, limit)).thenReturn(resultSet);
+
+        var servResp = service.getPackageCallgraph(pkgName, pkgVersion, offset, limit, mdDao);
+
+//        assertEquals(response, servResp);
+        // FIXME: this might not work. Needs to find a way to assert the entity content and not the response object
+
+        verify(mdDao, times(1)).getPackageCallgraph(pkgName, pkgVersion, offset, limit);
+    }
+
+}


### PR DESCRIPTION
## Description
I tried to be as clear as possible within my entire commits messages and timeline.
During the development, I got several bugs with `nullPointerException` because I couldn't find a way to mock the kb connection from the rest api plugin.

While I was looking into other plugins unit tests I also notice that they might not have found a way to mock this "db plugin connection" either, so they decided to add the mdDao as an argument to the methods.

I tested this approach with the `PackageServiceImpl` and it was successfully proven to be simpler to mock.